### PR TITLE
[TESTS] Add global random seed for deterministic test

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: (c) 2021 Artёm IG <github.com/rtmigo>
+# SPDX-License-Identifier: MIT
+
+import random
+
+# Fixed seed for reproducible test runs.
+random.seed(17)


### PR DESCRIPTION
## Description

This PR sets a fixed global random seed for each pytest session, making tests deterministic and easier to debug.

## Motivation

Some tests rely on randomness without setting an explicit seed. This can result in nondeterministic behavior and make failures difficult to reproduce, especially in CI environments.

## Changes

A global random seed is initialized at the beginning of each pytest session to ensure consistent behavior across test runs.

## Benefits

- Reproducible test results
- Easier debugging of failures
- More consistent CI behavior

The issue was identified during an ongoing research project.